### PR TITLE
wallet: fix "null" backup file name and not rolling automatic backup

### DIFF
--- a/src/qt/freedomcoin/coldstakingwidget.cpp
+++ b/src/qt/freedomcoin/coldstakingwidget.cpp
@@ -228,7 +228,7 @@ void ColdStakingWidget::loadWalletModel()
 
 }
 
-void ColdStakingWidget::onTxArrived(const QString& hash, const bool isCoinStake, const bool isCSAnyType)
+void ColdStakingWidget::onTxArrived(const QString& hash, const bool isCoinStake, const bool isPNReward, const bool isCSAnyType)
 {
     if (isCSAnyType) {
         tryRefreshDelegations();

--- a/src/qt/freedomcoin/coldstakingwidget.h
+++ b/src/qt/freedomcoin/coldstakingwidget.h
@@ -69,7 +69,7 @@ private Q_SLOTS:
     void onCopyOwnerClicked();
     void onAddressCopyClicked();
     void onAddressEditClicked();
-    void onTxArrived(const QString& hash, const bool isCoinStake, const bool isCSAnyType);
+    void onTxArrived(const QString& hash, const bool isCoinStake, const bool isPNReward, const bool isCSAnyType);
     void onContactsClicked(bool ownerAdd);
     void clearAll();
     void onLabelClicked();

--- a/src/qt/freedomcoin/dashboardwidget.h
+++ b/src/qt/freedomcoin/dashboardwidget.h
@@ -81,9 +81,9 @@ public:
     QMap<int, std::pair<qint64, qint64>> amountsByCache;
     qreal maxValue = 0;
     qint64 totalPiv = 0;
-    qint64 totalZpiv = 0;
+    qint64 totalPN = 0;
     QList<qreal> valuesPiv;
-    QList<qreal> valueszPiv;
+    QList<qreal> valuesPN;
     QStringList xLabels;
 };
 
@@ -122,7 +122,7 @@ private Q_SLOTS:
     void onSortTypeChanged(const QString& value);
     void updateDisplayUnit();
     void showList();
-    void onTxArrived(const QString& hash, const bool isCoinStake, const bool isCSAnyType);
+    void onTxArrived(const QString& hash, const bool isCoinStake, const bool isPNReward, const bool isCSAnyType);
 
 #ifdef USE_QTCHARTS
     void windowResizeEvent(QResizeEvent* event);
@@ -165,7 +165,7 @@ private:
     int yearFilter{0};
     int monthFilter{0};
     int dayStart{1};
-    bool hasZpivStakes{false};
+    bool hasPNRewards{false};
 
     ChartData* chartData{nullptr};
     bool hasStakes{false};
@@ -177,11 +177,11 @@ private:
     bool refreshChart();
     void tryChartRefresh();
     void updateStakeFilter();
-    const QMap<int, std::pair<qint64, qint64>> getAmountBy();
+    QMap<int, std::pair<qint64, qint64>> getAmountBy();
     bool loadChartData(bool withMonthNames);
     void updateAxisX(const QStringList *arg = nullptr);
     void setChartShow(ChartShowType type);
-    std::pair<int, int> getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy);
+    std::pair<int, int> getChartRange(const QMap<int, std::pair<qint64, qint64>>& amountsBy);
 
 private Q_SLOTS:
     void onChartRefreshed();

--- a/src/qt/freedomcoin/forms/dashboardwidget.ui
+++ b/src/qt/freedomcoin/forms/dashboardwidget.ui
@@ -512,14 +512,14 @@
                </size>
               </property>
               <property name="text">
-               <string>Staking Rewards</string>
+               <string>Staking/PN Rewards</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="labelMessage">
               <property name="text">
-               <string>Amount of staking rewards received.</string>
+               <string>Amount of FREED stakes and patriotnodes rewards.</string>
               </property>
              </widget>
             </item>
@@ -567,7 +567,7 @@
           <item>
            <widget class="QLabel" name="labelAmountPiv">
             <property name="text">
-             <string notr="true">0 FREED</string>
+             <string notr="true">0 Stakes</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -575,9 +575,9 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="labelAmountZpiv">
+           <widget class="QLabel" name="labelAmountPN">
             <property name="text">
-             <string notr="true">0 zFREED</string>
+              <string notr="true">0 PN</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -655,7 +655,7 @@
                 <item>
                  <widget class="QLabel" name="labelChart">
                   <property name="text">
-                   <string>Staking statistics</string>
+                   <string>Rewards statistics</string>
                   </property>
                  </widget>
                 </item>
@@ -694,7 +694,7 @@
                 <item>
                  <widget class="QLabel" name="labelPiv">
                   <property name="text">
-                   <string notr="true">FREED</string>
+                   <string notr="true">Stakes</string>
                   </property>
                  </widget>
                 </item>
@@ -715,7 +715,7 @@
                  </spacer>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelSquarezPiv">
+                 <widget class="QLabel" name="labelSquarePN">
                   <property name="minimumSize">
                    <size>
                     <width>14</width>
@@ -734,9 +734,9 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelZpiv">
+                 <widget class="QLabel" name="labelPN">
                   <property name="text">
-                   <string notr="true">zFREED</string>
+                    <string>Patriotnode</string>
                   </property>
                  </widget>
                 </item>

--- a/src/qt/freedomcoin/res/css/style_dark.css
+++ b/src/qt/freedomcoin/res/css/style_dark.css
@@ -1839,14 +1839,14 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     border-bottom: 5px solid #69656F;
 }
 
-*[cssClass="text-stake-zpiv"] {
+*[cssClass="text-stake-pn"] {
     color:#b088ff;
     font-size:16px;
     padding:10px;
     border-bottom: 5px solid #b088ff;
 }
 
-*[cssClass="text-stake-zpiv-disable"] {
+*[cssClass="text-stake-pn-disable"] {
     color:#423E4A;
     font-size:16px;
     padding:10px;
@@ -1858,7 +1858,7 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     font-size:16px;
 }
 
-*[cssClass="text-chart-zpiv"] {
+*[cssClass="text-chart-pn"] {
     color:#b088ff;
     font-size:16px;
     padding-left:4px;
@@ -1870,7 +1870,7 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     padding-left:4px;
 }
 
-*[cssClass="square-chart-zpiv"] {
+*[cssClass="square-chart-pn"] {
     background-color:#b088ff;
     border:none;
 }

--- a/src/qt/freedomcoin/res/css/style_light.css
+++ b/src/qt/freedomcoin/res/css/style_light.css
@@ -1839,14 +1839,14 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     border-bottom: 5px solid #bbb8c0;
 }
 
-*[cssClass="text-stake-zpiv"] {
+*[cssClass="text-stake-pn"] {
     color:#b088ff;
     font-size:16px;
     padding:10px;
     border-bottom: 5px solid #b088ff;
 }
 
-*[cssClass="text-stake-zpiv-disable"] {
+*[cssClass="text-stake-pn-disable"] {
     color:#d7d5da;
     font-size:16px;
     padding:10px;
@@ -1858,7 +1858,7 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     font-size:16px;
 }
 
-*[cssClass="text-chart-zpiv"] {
+*[cssClass="text-chart-pn"] {
     color:#b088ff;
     font-size:16px;
     padding-left:4px;
@@ -1870,7 +1870,7 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     padding-left:4px;
 }
 
-*[cssClass="square-chart-zpiv"] {
+*[cssClass="square-chart-pn"] {
     background-color:#b088ff;
     border:none;
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -640,7 +640,12 @@ int TransactionRecord::getOutputIndex() const
 
 bool TransactionRecord::isCoinStake() const
 {
-    return (type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || type == TransactionRecord::StakeZFREED);
+    return type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || type == TransactionRecord::StakeZFREED;
+}
+
+bool TransactionRecord::isPNReward() const
+{
+    return type == TransactionRecord::PNReward;
 }
 
 bool TransactionRecord::isAnyColdStakingType() const

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -196,6 +196,9 @@ public:
     /** Return true if the tx is a coinstake
      */
     bool isCoinStake() const;
+	
+	/** Return true if the tx is a MN reward */
+    bool isPNReward() const;
 
     /** Return true if the tx is a any cold staking type tx.
      */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -325,7 +325,7 @@ void TransactionTableModel::updateTransaction(const QString& hash, int status, b
     priv->updateWallet(updated, status, showTransaction, rec);
 
     if (!rec.isNull())
-        Q_EMIT txArrived(hash, rec.isCoinStake(), rec.isAnyColdStakingType());
+        Q_EMIT txArrived(hash, rec.isCoinStake(), rec.isPNReward(), rec.isAnyColdStakingType());
 }
 
 void TransactionTableModel::updateConfirmations()

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -83,7 +83,7 @@ public:
     bool processingQueuedTransactions() const { return fProcessingQueuedTransactions; }
 
 Q_SIGNALS:
-    void txArrived(const QString& hash, const bool isCoinStake, const bool isCSAnyType);
+    void txArrived(const QString& hash, const bool isCoinStake, const bool isPNReward, const bool isCSAnyType);
 
 private:
     // Listeners

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4370,7 +4370,8 @@ bool CWalletTx::AcceptToMemoryPool(CValidationState& state)
 
 std::string CWallet::GetUniqueWalletBackupName() const
 {
-    return strprintf("%s%s", (!m_name.empty() ? SanitizeString(m_name, SAFE_CHARS_FILENAME) : "null"), FormatISO8601DateTimeForBackup(GetTime()));
+    std::string name = !m_name.empty() ? SanitizeString(m_name, SAFE_CHARS_FILENAME) : "wallet_backup";
+    return strprintf("%s%s", name, FormatISO8601DateTimeForBackup(GetTime()));
 }
 
 CWallet::CWallet(std::string name, std::unique_ptr<CWalletDBWrapper> dbw) : m_name(std::move(name)), dbw(std::move(dbw))

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -893,7 +893,7 @@ bool AutoBackupWallet(CWallet& wallet, std::string& strBackupWarning, std::strin
     }
 
     // Keep only 0 < nWalletBackups <= 10 backups, including the new one of course
-    folder_set_t folder_set = buildBackupsMapSortedByLastWrite(strWalletFile, backupsDir);
+    folder_set_t folder_set = buildBackupsMapSortedByLastWrite(backupFile.stem().string(), backupsDir);
     return cleanWalletBackups(folder_set, nWalletBackups, strBackupWarning);
 }
 


### PR DESCRIPTION
 New created wallets have no name set by default, thus the `GetUniqueWalletBackupName` function returns "null", and the automatic backup process creates a backup file with a name in the form of "null+date".

Changed the label to "wallet_backup" instead of "null" if the wallet has no name.